### PR TITLE
[BE] 결제 API 적용 및 결제 테이블 CRUD 구현, 간단한 테스트 HTML 생성 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ out/
 
 ##application.yml
 src/main/resources/application.yml
+
+##application.properties
+
+src/main/resources/application.properties

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,13 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation 'com.github.iamport:iamport-rest-client-java:0.2.21'
+
+    allprojects {
+        repositories {
+            maven { url 'https://jitpack.io' }
+        }
+    }
 }
 
 tasks.named('test') {

--- a/src/main/java/com/estsoft/paldotourism/controller/PaymentHistoryController.java
+++ b/src/main/java/com/estsoft/paldotourism/controller/PaymentHistoryController.java
@@ -1,0 +1,56 @@
+package com.estsoft.paldotourism.controller;
+
+import com.estsoft.paldotourism.service.PaymentHistoryService;
+import com.siot.IamportRestClient.IamportClient;
+import com.siot.IamportRestClient.exception.IamportResponseException;
+import com.siot.IamportRestClient.response.IamportResponse;
+import com.siot.IamportRestClient.response.Payment;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.io.IOException;
+
+@Controller
+@Slf4j
+public class PaymentHistoryController {
+
+    private IamportClient iamportClient;
+
+    private final PaymentHistoryService paymentHistoryService;
+
+    @Value("${imp.api.key}")
+    private String apiKey;
+
+    @Value("${imp.api.secretkey}")
+    private String secretKey;
+
+    public PaymentHistoryController(PaymentHistoryService paymentHistoryService) {
+        this.paymentHistoryService = paymentHistoryService;
+    }
+
+    @PostConstruct
+    public void init() {
+        this.iamportClient = new IamportClient(apiKey, secretKey);
+    }
+
+
+    @ResponseBody
+    @RequestMapping("/verify/{imp_uid}")
+    public IamportResponse<Payment> paymentByImpUid(@PathVariable("imp_uid") String imp_uid)
+            throws IamportResponseException, IOException {
+
+        paymentHistoryService.createPaymentHistory();
+
+
+        log.info("결제 성공");
+
+        return iamportClient.paymentByImpUid(imp_uid);
+    }
+
+}

--- a/src/main/java/com/estsoft/paldotourism/entity/PaymentHistory.java
+++ b/src/main/java/com/estsoft/paldotourism/entity/PaymentHistory.java
@@ -1,20 +1,31 @@
 package com.estsoft.paldotourism.entity;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @EntityListeners(AuditingEntityListener.class)
 @Entity
+@NoArgsConstructor
+@AllArgsConstructor
 public class PaymentHistory {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id; // 결제 아이디(PK)
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn
-    private Reservation reservation; // 예약 정보(FK)
-
     @Column
-    private Integer totalCharge; // 총 결제 금액
+    private Boolean paymentStatus; // 결제 상태(성공, 실패)
+
+    @Builder
+    public PaymentHistory(Boolean paymentStatus)
+    {
+        this.paymentStatus = paymentStatus;
+    }
+
+    public void update(Boolean status) {
+        paymentStatus = status;
+    }
 }

--- a/src/main/java/com/estsoft/paldotourism/service/PaymentHistoryService.java
+++ b/src/main/java/com/estsoft/paldotourism/service/PaymentHistoryService.java
@@ -1,0 +1,53 @@
+package com.estsoft.paldotourism.service;
+
+import com.estsoft.paldotourism.entity.PaymentHistory;
+import com.estsoft.paldotourism.repository.PaymentHistoryRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class PaymentHistoryService {
+
+    private final PaymentHistoryRepository paymentHistoryRepository;
+
+    public PaymentHistoryService(PaymentHistoryRepository paymentHistoryRepository) {
+        this.paymentHistoryRepository = paymentHistoryRepository;
+    }
+
+    // 결제 기록 저장
+    public void createPaymentHistory() {
+
+        PaymentHistory paymentHistory = PaymentHistory.builder().paymentStatus(true).build();
+        paymentHistoryRepository.save(paymentHistory);
+
+    }
+
+    // 결제 기록 조회(1개)
+    public PaymentHistory getPaymentHistory(Integer id) {
+
+        PaymentHistory paymentHistory = paymentHistoryRepository.findById(id).get();
+
+        return paymentHistory;
+    }
+
+    // 결제 기록 삭제
+    public void deletePaymentHistory(Integer id) {
+
+        PaymentHistory paymentHistory = paymentHistoryRepository.findById(id).get();
+
+        paymentHistoryRepository.deleteById(id);
+    }
+
+
+    // 결제 기록 상태 수정
+    @Transactional
+    public PaymentHistory updatePaymentHistory (Integer id, Boolean status) {
+
+        PaymentHistory paymentHistory = paymentHistoryRepository.findById(id).get();
+
+        paymentHistory.update(status);
+
+        return paymentHistory;
+    }
+
+}

--- a/src/main/resources/templates/payment/payment.html
+++ b/src/main/resources/templates/payment/payment.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <!-- jQuery -->
+    <script src="http://code.jquery.com/jquery-latest.min.js" type="text/javascript"></script>
+    <!-- iamport.payment.js -->
+    <script type="text/javascript" src="https://cdn.iamport.kr/js/iamport.payment-1.2.0.js"></script>
+
+
+    <script>
+        var IMP = window.IMP;
+        IMP.init("imp26578218");
+
+        function requestPay() {
+            IMP.request_pay({
+                    pg: "kakaopay",
+                    pay_method: "EASY_PAY",
+                    merchant_uid: `payment-${crypto.randomUUID()}`,   // 주문번호
+                    name: "서울 - 경기 버스 노선",
+                    amount: 10,                         // 숫자 타입
+                    buyer_email: "test@gmail.com",
+                    buyer_name: "김테스트",
+                    buyer_tel: "010-2623-7952"
+                },
+                function (rsp) {
+                    //rsp.imp_uid 값으로 결제 단건조회 API를 호출하여 결제결과를 판단합니다.
+                    if (rsp.success) {
+                        $.ajax({
+                            url: '/verify/' + rsp.imp_uid,
+                            method: "POST",
+                            // contentType: "application/json",
+                            // data: JSON.stringify({
+                            //     imp_uid: rsp.imp_uid,            // 결제 고유번호
+                            //     merchant_uid: rsp.merchant_uid,   // 주문번호
+                            //     amount: rsp.paid_amount
+                            // }),
+                        }).done(function (data) {
+                            // 가맹점 서버 결제 API 성공시 로직
+                            if (rsp.paid_amount === data.response.amount) {
+                                alert("결제 성공");
+                                // console.log(rsp);
+                                // console.log(data.response);
+                            }
+                        })
+                    } else {
+                        alert(rsp.error_msg);
+                    }
+                }
+            );
+        }
+    </script>
+    <meta charset="UTF-8">
+    <title>Sample Payment</title>
+</head>
+<body>
+<button onclick="requestPay()">결제하기</button> <!-- 결제하기 버튼 생성 -->
+</body>
+</html>


### PR DESCRIPTION
## 작업 내용
포트원(아임포트) API 적용을 위해 build.gradle 의존성을 추가하고 결제 API를 적용했습니다

또한 application.properties에 결제 API 키가 있어서 gitgnore에 application.properties를 추가해서 올라가지 않게했습니다

결제 수단은 카카오페이로 하였습니다. 결제를 중간에 그만두면 어떤 이유로 결제가 실패하였는지 메시지를 띄워줍니다.

성공을 하게 되면 임시로 alert로 성공했다고 알림을 해줍니다

결제를 성공하게 되면 결제 이력 컨트롤러를 호출해서 추가하는 로직까지 구현 했습니다. 그 밖에 연결은 하지 않았지만 나머지 CRUD 기능 또한 구현을 해뒀습니다

다만 테스트를 꺼내고 원래 구조로 돌리고 뷰 컨트롤러를 만들진 않아 결제 페이지가 있어도 **해당 페이지로 연결**하지는 못합니다.


카카오 페이 결제창

![PR 사진](https://github.com/paldo-tourism/paldo-tourism/assets/133013702/bde1cddc-875b-4130-b1e7-4ea5c314f134)


결제 실패 알림창

![결제실패](https://github.com/paldo-tourism/paldo-tourism/assets/133013702/99471c00-4a67-4e33-a502-9ca531b60c8d)



## 이슈 번호
#22 
